### PR TITLE
Remove unnecessary dependency for table data builder

### DIFF
--- a/builders/column_data_builder.py
+++ b/builders/column_data_builder.py
@@ -22,11 +22,9 @@ class ColumnDataBuilder:
         self,
         files_stats: Dict[str, List[FileCommitStats]],
         flat_file_tree: List[str],
-        repo_instance: Repo,
         **kwargs: Unpack[ColumnBuilderKwargs],
     ):
         self._files_stats = files_stats
-        self.repo_instance = repo_instance
         self.flat_file_tree = flat_file_tree
         self.pathname_length = kwargs.get("pathname_length", 2)
         self._columns: OrderedDict[str, List[str]] = OrderedDict()

--- a/builders/column_data_builder.py
+++ b/builders/column_data_builder.py
@@ -2,7 +2,6 @@
 
 from typing import Unpack, List, Self, Callable, Dict
 from collections import OrderedDict
-from git import Repo
 from app_types.dataclasses import FileCommitStats
 from app_types.utils import ColumnBuilderKwargs
 from decorators.column_building_method import column_building_method

--- a/command_interface/option_processors.py
+++ b/command_interface/option_processors.py
@@ -67,7 +67,6 @@ def process_query(
         ColumnDataBuilder(
             all_files_stats,
             flat_file_tree,
-            repo,
             pathname_length=2,
         )
     )


### PR DESCRIPTION
After double checking, table data builder actually calculates all the data. So removing it would not benefit the app logic